### PR TITLE
Add string functionality from the spelling corrector

### DIFF
--- a/rhombus-compat-test/test-string.rkt
+++ b/rhombus-compat-test/test-string.rkt
@@ -1,0 +1,40 @@
+#lang rhombus
+// Tests passes if all results are #true
+
+import:
+  "../rhombus-compat/compat/string.rkt":           no_prefix   // for static s[range]
+  // "../rhombus-compat/compat/string-private.rkt":   no_prefix   // for String and dot
+  "../rhombus-compat/compat/range.rkt":            no_prefix   // -- and --=
+  "../rhombus-compat/compat/map-ref.rkt":          no_prefix   // for dynamic s[range]
+  rhombus/macro:                                   no_prefix
+// Used as annotation
+def s : "foobar" :: String
+
+// Used as predicate
+("foo" is_a String)===#true
+(42    is_a String)===#false
+
+// Reference
+s[0]===#{#\f}
+s[2--3]==="o"
+s[2--=3]==="ob"
+s[1--end]==="oobar"
+s[--2]==="fo"
+s[--=2]==="foo"
+
+// Dynamic reference
+def t : "bar"
+t[0]===#{#\b}
+
+// Binding syntax
+def middle(String(a,_,b)): [a,b]
+middle("xyz")===[#{#\x},#{#\z}]
+
+// Mutation
+// s[1]=#{#\a}
+// s==="fao"
+
+// Dot
+s.length
+                                  
+                                  

--- a/rhombus-compat/compat/map-ref.rkt
+++ b/rhombus-compat/compat/map-ref.rkt
@@ -1,0 +1,95 @@
+#lang racket/base
+;;;
+;;; References
+;;;
+
+; This files takes care of references of the form s[e],
+; where the static info associated to s default to the dynamic
+; handling below.
+
+; This file extends the standard #%ref with a new version that
+; also handles strings
+
+(provide (rename-out [my-#%ref #%ref]))
+
+
+(require rhombus/private/expression
+         rhombus/private/parse
+         rhombus/private/static-info
+         ; (only-in rhombus/private/map-ref map-ref) ; map-ref wasn't exported
+         (submod rhombus/private/map-ref for-ref)
+         (submod rhombus/private/set     for-ref)
+         (rename-in (only-in rhombus =) [= rhombus=])
+         (for-syntax racket/base
+                     syntax/parse
+                     rhombus/private/expression
+                     rhombus/private/srcloc))
+
+
+; See rhombus/private/map-ref.rkt for the original
+(define-for-syntax (parse-map-ref-or-set map stxes)
+  (syntax-parse stxes
+    #:datum-literals (brackets group op block)
+    #:literals (rhombus=)
+    [(_ ((~and head brackets) index) (op rhombus=) . rhs+tail)
+     #:with rhs::infix-op+expression+tail #'(rhombus= . rhs+tail)
+     (define map-set!-id (or (syntax-local-static-info map #'#%map-set!)
+                                 #'map-set!))
+     (define e (datum->syntax (quote-syntax here)
+                              (list map-set!-id map #'(rhombus-expression index) #'rhs.parsed)
+                              (span-srcloc map #'head)
+                              #'head))
+     (values e
+             #'rhs.tail)]
+    [(_ ((~and head brackets) (group #:from (block index))) . tail)
+     (define e (datum->syntax (quote-syntax here)
+                              (list #'substring map #'(rhombus-expression index))
+                              (span-srcloc map #'head)
+                              #'head))
+     (define result-static-infos (or (syntax-local-static-info map #'#%ref-result)
+                                     #'()))
+     (values (wrap-static-info* e result-static-infos)
+             #'tail)]
+    [(_ ((~and head brackets) (group #:to (block index))) . tail)
+     (define e (datum->syntax (quote-syntax here)
+                              (list #'tostring map #'(rhombus-expression index))
+                              (span-srcloc map #'head)
+                              #'head))
+     (define result-static-infos (or (syntax-local-static-info map #'#%ref-result)
+                                     #'()))
+     (values (wrap-static-info* e result-static-infos)
+             #'tail)]
+    [(_ ((~and head brackets) index) . tail)
+     (define map-ref-id (or (syntax-local-static-info map #'#%map-ref)
+                            #'map-ref))
+     (define e (datum->syntax (quote-syntax here)
+                              (list map-ref-id map #'(rhombus-expression index))
+                              (span-srcloc map #'head)
+                              #'head))
+     (define result-static-infos (or (syntax-local-static-info map #'#%ref-result)
+                                     #'()))
+     (values (wrap-static-info* e result-static-infos)
+             #'tail)]))
+
+(define-syntax my-#%ref  
+  (expression-infix-operator
+   #'#%ref
+   '((default . stronger))
+   'macro
+   (lambda (array stxes)
+     (parse-map-ref-or-set array stxes))
+   'left))
+
+(require (only-in "string-common.rkt" string-ref*))
+
+(define (map-ref map index)
+  (cond
+    [(vector? map) (vector-ref map index)]
+    [(list? map)   (list-ref map index)]
+    [(hash? map)   (hash-ref map index)]
+    [(set? map)    (hash-ref (set-ht map) index #f)]
+    [(string? map) (string-ref* map index)]               ; added [soegaard]
+    [else
+     (raise-argument-error 'my-map-ref "my-map?" map)]))
+
+(define (tostring s i) (substring s 0 i))

--- a/rhombus-compat/compat/range-private.rkt
+++ b/rhombus-compat/compat/range-private.rkt
@@ -1,0 +1,34 @@
+#lang racket/base
+(provide range-start
+         range-end
+         make-range
+         (struct-out range))
+
+; (provide (for-space rhombus make-range))
+
+;;;
+;;; Ranges
+;;;
+
+; For now a spec is simply a (list start end),
+; where #f means 0 or infinity respectively.
+
+; For arrays generalized ranges as in srfi 179 it is possible
+; for the spec to be a list of intervals.
+
+(struct range (single? spec))
+
+(define (range-start r)
+  (car (range-spec r)))
+
+(define (range-end r)
+  (cadr (range-spec r)))
+
+(define (make-range a b)
+  (range #t (list a b)))
+
+
+
+         
+  
+

--- a/rhombus-compat/compat/range.rkt
+++ b/rhombus-compat/compat/range.rkt
@@ -1,0 +1,19 @@
+#lang rhombus
+
+import:
+  "range-private.rkt": no_prefix
+
+export:
+  end
+  --
+  --=
+
+def end : #false
+
+operator
+| (a -- b) : #{make-range}(a,b)
+| (  -- b) : #{make-range}(#false,b)
+             
+operator
+| (a --= b) : #{make-range}(a,b+1)
+| (  --= b) : #{make-range}(#false,b+1)

--- a/rhombus-compat/compat/string-common.rkt
+++ b/rhombus-compat/compat/string-common.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(require "range-private.rkt")
+(provide string-ref*)
+
+; Functions defined here are exported to the Rhombus layer.
+
+(define (string-ref* s i)
+  (cond
+    [(integer? i)
+     (string-ref s i)]
+    [(and (list? i) (= (length i) 2))
+     (define from (list-ref i 0))
+     (define to   (list-ref i 1))
+     (cond
+       [(and from to) (substring s from to)]
+       [from          (substring s from)]
+       [to            (substring s 0 to)])]
+    [(range? i)
+     (string-ref* s (range-spec i))]
+    [else
+     (raise-argument-error 'string-ref* "expected a range")]))

--- a/rhombus-compat/compat/string-private.rkt
+++ b/rhombus-compat/compat/string-private.rkt
@@ -1,0 +1,126 @@
+#lang racket/base
+(require (for-syntax racket/base syntax/parse)
+         rhombus/private/binding
+         rhombus/private/static-info
+         rhombus/private/map-ref-set-key
+         rhombus/private/call-result-key
+         rhombus/private/composite
+         (submod rhombus/private/annotation for-class))
+
+;;;
+;;; 4.4. String
+;;;
+
+; Section "4.4. Strings" in the references:
+; https://docs.racket-lang.org/reference/strings.html
+
+;;; Goals
+; - use short names
+; - the annotation for strings are String
+; - s.name becomes  (string-name s), when s is declared to be a String
+; - string reference, s[ ] can be used for indexing as well as substrings
+
+;;; Reference
+; Constructor: String
+
+; s[i]      = stringref(s,i)
+; s[i--j]   = substring(s,i,j)
+; s[i--end] = substring(s,i)
+; s[ --j]   = substring(0,j)
+
+; Note: The operator -- is defined in "range.rkt"
+;       and produces a list of two elements:
+;       the indices i and j.
+;       False indicates beginning or end.
+
+
+;;;
+;;; Constructor
+;;;
+(define String string)
+(provide String
+         (for-space rhombus/binding     String)
+         (for-space rhombus/annotation  String)
+         (for-space rhombus/static-info String))
+
+;;;
+;;; String Reference / String Slppicing
+;;;
+
+; We need a slightly extended version of string-ref in order
+; to support ranges in the s[ ] notation.
+
+(require (only-in "string-common.rkt" string-ref*))
+
+#;(define (string-ref* s i)
+    (cond
+      [(integer? i)
+       (string-ref s i)]
+      [(and (list? i) (= (length i) 2))
+       (define from (list-ref i 0))
+       (define to   (list-ref i 1))
+       (cond
+         [(and from to) (substring s from to)]
+         [from          (substring s from)]
+         [to            (substring s 0 to)])]
+      [else
+       (raise-argument-error 'string-ref* "expected a range")]))
+
+;;;
+;;; String Annotation
+;;; 
+
+;; Static Info
+
+(define-for-syntax string-static-info
+  #'((#%map-ref    string-ref*)
+     ; (#%map-set!   string-set!)
+     (#%map-append string-append)))
+; Note: These strings aren't mutable, so set! is commented out.
+
+(define-annotation-syntax String
+  (annotation-constructor #'String #'string? string-static-info
+                          1
+                          (lambda (arg-id predicate-stxs)
+                            #`(for/and ([e (in-string #,arg-id)])
+                                (#,(car predicate-stxs) e)))
+                          (lambda (static-infoss)
+                            #`((#%ref-result #,(car static-infoss))))))
+
+(define-static-info-syntax String
+  (#%call-result ((#%map-ref  string-ref*)
+                  ; (#%map-set! string-set!)
+                  (#%map-append string-append))))
+
+;;;
+;;; Binding Syntax
+;;;
+
+; The bindings syntax determines what happens in the case where String
+; appears in a binding position. A formal argument is one such place:
+;    def middle(String(a,_,b)): [a,b]
+;    middle("xyz")===[#{#\x},#{#\z}]
+; For now the binding syntax supports strings of a fixed length only.
+; TODO: What should the syntax be for a "rest argument".
+
+(define-binding-syntax String
+  (binding-prefix-operator
+   #'String
+   '((default . stronger))
+   'macro
+   (lambda (stx)
+     (syntax-parse stx
+       [(form-id ((~and tag (~datum parens)) arg ...) . tail)
+        (define args (syntax->list #'(arg ...)))
+        (define len (length args))
+        (define pred #`(lambda (v)
+                         (and (string? v)
+                              (= (string-length v) #,len))))
+        ((make-composite-binding-transformer pred
+                                             (for/list ([arg (in-list args)]
+                                                        [i   (in-naturals)])
+                                               #`(lambda (v) (string-ref v #,i)))
+                                             (for/list ([arg (in-list args)])
+                                               #'())
+                                             #:ref-result-info? #t)
+         stx)]))))

--- a/rhombus-compat/compat/string.rkt
+++ b/rhombus-compat/compat/string.rkt
@@ -1,17 +1,252 @@
 #lang rhombus
+///
+/// 4.4. String
+///
 
-// FIXME: Steal @soegaard's code instead
-// https://github.com/soegaard/rhombus-experiments/blob/main/spelling-corrector/string.rkt
+// Section "4.4. Strings" in the references:
+// https://docs.racket-lang.org/reference/strings.html
+
+//// Goals
+//  - Short names
+//       The intended usage is:
+//            import: compat/string: prefix string
+//       Then string.append, string.= etc are available.
+
+//  - String annotation
+//       s.name becomes  (string-name s), when s is declared to be a String
+//  - string reference, s[ ] can be used for indexing as well as substrings
+
+// Note: The list of renames are made explicit below.
+//       It helps when grepping for names.
+
 
 import:
+  rhombus/macro:        no_prefix // for defining dot provider
+  "string-private.rkt": no_prefix
+
   racket/base:
-    prefix string
+    prefix base
     rename:
-      #{string->number} ~to to_number
-      #{string-append} ~to sappend
+      // 4.4.1 String constructors, selectors and mutators
+      #{string?}                  ~to is_string
+      #{make-string}              ~to make
+      #{string}                   ~to string
+      #{string->immutable-string} ~to to_immutable
+      #{string-length}            ~to string_length   // exported as length
+      #{string-ref}               ~to ref
+      #{string-set!}              ~to set
+      #{substring}                ~to sub
+      #{string-copy}              ~to copy
+      #{string-copy!}             ~to copy_bang       // todo - convention for bang?
+      #{string-fill!}             ~to fill            // todo - convention for bang?
+      #{string-append}            ~to string_append   // exported as append
+      #{string-append-immutable}  ~to append_immutable
+      #{string->list}             ~to to_list
+      #{list->string}             ~to from_list   
+      #{build-string}             ~to build_string
+
+      // 4.4.2 String comparisons
+      #{string=?}                 ~to string_equal         // exported as =
+      #{string<?}                 ~to string_less          // exported as <
+      #{string<=?}                ~to string_less_equal    // exported as <=
+      #{string>?}                 ~to string_greater       // exported as >
+      #{string>=?}                ~to string_greater_equal // exported as >=
+      #{string-ci=?}              ~to ci_equal
+      #{string-ci<?}              ~to ci_less
+      #{string-ci<=?}             ~to ci_less_equal
+      #{string-ci>?}              ~to ci_greater
+      #{string-ci>=?}             ~to ci_greater_equal
+      
+      // 4.4.3 String Conversions
+      #{string-upcase}            ~to upcase
+      #{string-downcase}          ~to downcase
+      #{string-titlecase}         ~to titlecase
+      #{string-foldcase}          ~to foldcase
+      #{string-normalize-nfd}     ~to normalize_nfd
+      #{string-normalize-nfkd}    ~to normalize_nfkd
+      #{string-normalize-nfc}     ~to normalize_nfc
+      #{string-normalize-nfkc}    ~to normalize_nfkc
+      
+      // 4.4.4 Locale-Specific String Operations
+      #{string-locale=?}          ~to locale_equal
+      #{string-locale<?}          ~to locale_less
+      #{string-locale>?}          ~to locale_greater
+      #{string-locale-ci=?}       ~to locale_ci_equal
+      #{string-locale-ci<?}       ~to locale_ci_less
+      #{string-locale-ci>?}       ~to locale_ci_greater
+      #{string-locale-upcase}     ~to locale_upcase
+      #{string-locale-downcase}   ~to locale_downcase
+
+  racket/string:
+        prefix string
+        rename:
+          // 4.4.5 Additional String Functions
+          #{string-append*}          ~to appends  // todo: * = s ?
+          #{string-join}             ~to join
+          #{string-normalize-spaces} ~to normalize_spaces
+          #{string-replace}          ~to replace
+          #{string-split}            ~to split
+          #{string-trim}             ~to trim
+          #{non-empty-string?}       ~to is_non_empty
+          #{string-contains?}        ~to contains   // todo: is_contains doesn't sound right
+          #{string-prefix?}          ~to is_prefix
+          #{string-suffix?}          ~to is_suffix
+          
+  racket/format:
+        prefix format
+        rename:
+          // 4.4.6 Converting Values to Strings
+          #{~a}          ~to tilde_a
+          #{~v}          ~to tilde_v
+          #{~s}          ~to tilde_s
+          #{~e}          ~to tilde_e
+          #{~r}          ~to tilde_r
+          #{~.a}         ~to tilde_dot_a
+          #{~.v}         ~to tilde_dot_v
+          #{~.s}         ~to tilde_dot_s
+      
+export:
+  // The annotation and reference
+  all_from("string-private.rkt") // does not export String and dots ???
+  String
+  string_dot_provider
+  
+  // 4.4.1 String constructors, selectors and mutators
+  rename:
+    base.is_string ~to is_string
+    base.string ~to string
+    base.make ~to make
+    base.to_immutable ~to to_immutable
+    base.ref ~to ref
+    base.set ~to set
+    base.sub ~to sub
+    base.copy ~to copy
+    base.copy_bang ~to  copy_bang
+    base.fill ~to fill
+    base.append_immutable ~to append_immutable
+    base.to_list ~to to_list
+    base.from_list ~to from_list
+    base.build_string ~to build_string
+    base.string_length ~to length
+    base.string_append ~to append
+    // 4.4.2 String comparisons
+    base.string_equal         ~to =
+    base.string_less          ~to <
+    base.string_less_equal    ~to <=
+    base.string_greater       ~to >
+    base.string_greater_equal ~to >=
+    base.ci_equal             ~to ci_equal
+    base.ci_less              ~to ci_less
+    base.ci_less_equal        ~to ci_less_equal
+    base.ci_greater           ~to ci_greater
+    base.ci_greater_equal     ~to ci_greater_equal
+    
+    // 4.4.3 String Conversions
+    base.upcase         ~to upcase
+    base.downcase       ~to downcase
+    base.titlecase      ~to titlecase
+    base.foldcase       ~to foldcase
+    base.normalize_nfd  ~to normalize_nfd
+    base.normalize_nfkd ~to normalize_nfkd
+    base.normalize_nfc  ~to normalize_nfc
+    base.normalize_nfkc ~to normalize_nfkc
+
+    // 4.4.4 Locale-Specific String Operations
+    base.locale_equal      ~to locale_equal
+    base.locale_less       ~to locale_less
+    base.locale_greater    ~to locale_greater
+    base.locale_ci_equal   ~to locale_ci_equal
+    base.locale_ci_less    ~to locale_ci_less
+    base.locale_ci_greater ~to locale_ci_greater
+    base.locale_upcase     ~to locale_upcase
+    base.locale_downcase   ~to locale_downcase
+    // 4.4.5 Additional String Functions
+    string.appends          ~to appends
+    string.join             ~to join
+    string.normalize_spaces ~to normalize_spaces
+    string.replace          ~to replace
+    string.split            ~to split
+    string.trim             ~to trim
+    string.is_non_empty     ~to is_non_empty
+    string.contains         ~to contains
+    string.is_prefix        ~to is_prefix
+    string.is_suffix        ~to is_suffix
+    
+    // 4.4.6 Converting Values to Strings
+    format.tilde_a     ~to tilde_a
+    format.tilde_v     ~to tilde_v
+    format.tilde_s     ~to tilde_s
+    format.tilde_e     ~to tilde_e
+    format.tilde_r     ~to tilde_r
+    format.tilde_dot_a ~to tilde_dot_a
+    format.tilde_dot_v ~to tilde_dot_v
+    format.tilde_dot_s ~to tilde_dot_s
 
 
-operator(a ++ b):
-  string.sappend(a, b)
 
-export: string ++
+/// Helpers
+fun stringify(x): if is_string(x) | x | base.string(x)
+def is_string: base.is_string
+def is_string_empty(x) : base.string_length(x)==0
+
+/// String Concatenation
+
+// Note: An n-ary string contenation operator would be better.
+operator (a ++ b):
+  ~associativity: ~right  
+  ~stronger_than: && ||                  
+  base.string_append(stringify(a),stringify(b))
+
+// String Dot Provider
+// If s is annotated with String, then we can use s.length etc
+
+// Note: Don't use `x is_a String` in the predicate. That's an infinite loop.
+annotation.macro 'String:
+  annotation_ct.pack_predicate('is_string,
+                               '(($(dot_ct.provider_key), string_dot_provider)))
+
+def ref: "ref"
+
+dot.macro '(string_dot_provider $left $dot $right):
+  // Note: The search for the right function is linear.
+  //       Place most often used function at the top.
+  match right
+  // One argument functions
+  | 'to_immutable:    '(base.to_immutable($left))
+  | 'length:          '(base.string_length($left))
+  | 'is_non_empty:    '(string.is_non_empty($left))
+  | 'is_empty:        '(is_string_empty($left))
+  | 'copy:            '(base.copy($left))
+  | 'to_list:         '(base.to_list($left))
+  | 'upcase:          '(base.upcase($left))      // todo: annotate that the result is a String
+  | 'downcase:        '(base.downcase($left))
+  | 'titlecase:       '(base.titlecase($left))
+  | 'foldcase:        '(base.foldcase($left))
+  | 'normalize_nfd:   '(base.normalize_nfd($left))
+  | 'normalize_nfkd:  '(base.normalize_nfkd($left))
+  | 'normalize_nfc:   '(base.normalize_nfc($left))
+  | 'normalize_nfkc:  '(base.normalize_nfkc($left))
+  | 'locale_upcase:   '(base.locale_upcase($left))      
+  | 'locale_downcase: '(base.locale_downcase($left))
+  | 'normalize_spaces: '(string.normalize_spaces($left))  // todo: other arguments?
+  | 'split:            '(string.split($left))  // todo: other arguments?
+  | 'trim:             '(string.trim($left))  // todo: other arguments?
+  
+  
+  // More arguments
+  | 'ref:          '(fun (k): base.ref($left,k))
+  | 'sub:          '(fun (start, end=#false):
+                       if end
+                       | base.sub($left,start,end)
+                       | base.sub($left,start))
+  | 'append:       '(fun (more): string.appends(cons($left,[more]))) // variadic? how?
+  | 'join:         '(fun (more): string.join(cons($left,more)))      // s.join(["bar","baz"])
+  | 'replace:      '(fun (from,to): string.replace($left,from,to))   // s.replace("o","x")
+  | 'contains:     '(fun (needle): string.contains($left,needle))
+  | 'is_prefix:    '(fun (needle): string.is_prefix($left,needle))
+  | 'is_suffix:    '(fun (needle): string.is_suffix($left,needle))
+                   
+
+// > val s: "foo" :: String
+// > s.length
+// 3


### PR DESCRIPTION
I added the folder `rhombus-compat-test` in which you will find `test-string.rkt`.

The ideal is for `string.rkt` (written in Rhombus) to export String and friends from "string-private.rkt",
but I can't figure out how to work with spaces in Rhombus. The test file thus imports "string-private.rkt". 

Help is needed to fix "string.rkt" so it exports everything.