### PR TITLE
Small repairs

### DIFF
--- a/rhombus-compat/compat/stream.rhm
+++ b/rhombus-compat/compat/stream.rhm
@@ -11,7 +11,7 @@ meta:
     export infos_key make_statinfo
     def infos_key = '#%stream_of_info'
 
-    fun make_statinfo(of_info = '()' :: Syntax):
+    fun make_statinfo(of_info :: Syntax = '()'):
       '(($(statinfo_meta.dot_provider_key), stream_dot_provider),
         ($(infos_key), $of_info))'
 

--- a/rhombus-compat/info.rkt
+++ b/rhombus-compat/info.rkt
@@ -5,5 +5,5 @@
 (define deps
   '("base"
     "rhombus-prototype"))
-(define module-suffixes '(#".rhm"))
+(define module-suffixes '(#"rhm"))
 


### PR DESCRIPTION
Fix a function argument, and remove a ".rhm" specification that seems to interfere with the one that's now in `rhombus-prototype`.